### PR TITLE
Add Testing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,3 +21,22 @@ jobs:
 
       - name: Build Project
         run: cmake --build build
+
+  test:
+    name: Test
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [Windows, Ubuntu, macOS]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+
+      - name: Configure Project
+        uses: threeal/cmake-action@v1.3.0
+        with:
+          options: BUILD_TESTING=ON
+
+      - name: Test Project
+        run: ctest -C debug --output-on-failure --test-dir build --no-tests=error

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,3 +10,14 @@ project(
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
 include(MkdirRecursive)
+
+if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR AND BUILD_TESTING)
+  enable_testing()
+
+  list(APPEND ARGS -B ${CMAKE_CURRENT_BINARY_DIR} -D CMAKE_MODULE_PATH=${CMAKE_MODULE_PATH})
+
+  add_test(
+    NAME MkdirRecursiveTest
+    COMMAND cmake ${ARGS} -P ${CMAKE_CURRENT_SOURCE_DIR}/test/MkdirRecursiveTest.cmake
+  )
+endif()

--- a/test/MkdirRecursiveTest.cmake
+++ b/test/MkdirRecursiveTest.cmake
@@ -1,0 +1,12 @@
+if(EXISTS ${CMAKE_CURRENT_BINARY_DIR}/parent)
+  file(REMOVE_RECURSE ${CMAKE_CURRENT_BINARY_DIR}/parent)
+endif()
+
+include(MkdirRecursive)
+mkdir_recursive(${CMAKE_CURRENT_BINARY_DIR}/parent/child)
+
+if(EXISTS ${CMAKE_CURRENT_BINARY_DIR}/parent/child)
+  file(REMOVE_RECURSE ${CMAKE_CURRENT_BINARY_DIR}/parent)
+else()
+  message(FATAL_ERROR "Directory `${CMAKE_CURRENT_BINARY_DIR}/parent/child` should exist!")
+endif()


### PR DESCRIPTION
This pull request adds a `MkdirRecursiveTest.cmake` file for testing functions inside the `MkdirRecursive.cmake` file. It also adds `test` job in the `ci.yaml` workflow for running test using `ctest` command. It closes #4.