### PR TITLE
Add Support for Installing Module File

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,8 +19,13 @@ jobs:
       - name: Configure Project
         uses: threeal/cmake-action@v1.3.0
 
-      - name: Build Project
-        run: cmake --build build
+      - name: Install Project
+        run: cmake --install build --prefix install
+
+      - name: Upload Project as Artifact
+        uses: actions/upload-artifact@v3.1.3
+        with:
+          path: install
 
   test:
     name: Test

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 !.git*
 
 build
+install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,3 +21,8 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR AND BUILD_TESTING)
     COMMAND cmake ${ARGS} -P ${CMAKE_CURRENT_SOURCE_DIR}/test/MkdirRecursiveTest.cmake
   )
 endif()
+
+install(
+  FILES cmake/MkdirRecursive.cmake
+  DESTINATION lib/cmake
+)


### PR DESCRIPTION
This pull request introduces the following changes:
- Add support for installing `MkdirRecursive.cmake` sample module file to `install/lib/cmake` directory.
- Modify the step for building project to steps for installing project and uploading the install result as a workflow artifact.

It closes #7.