### PR TITLE
Organize Sample Testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,13 +19,7 @@ endif()
 
 if(NOT SUBPROJECT AND BUILD_TESTING)
   enable_testing()
-
-  list(APPEND ARGS -B ${CMAKE_CURRENT_BINARY_DIR} -D CMAKE_MODULE_PATH=${CMAKE_MODULE_PATH})
-
-  add_test(
-    NAME MkdirRecursiveTest
-    COMMAND cmake ${ARGS} -P ${CMAKE_CURRENT_SOURCE_DIR}/test/MkdirRecursiveTest.cmake
-  )
+  add_subdirectory(test)
 endif()
 
 include(CMakePackageConfigHelpers)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.19)
 
 project(
   MyMkdir

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,4 +14,5 @@ endfunction()
 add_cmake_test(
   MkdirRecursiveTest.cmake
   "Create directory recursively"
+  # Add more test cases here.
 )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,17 @@
-list(APPEND ARGS -B ${CMAKE_CURRENT_BINARY_DIR} -D CMAKE_MODULE_PATH=${CMAKE_MODULE_PATH})
+function(add_cmake_test FILE)
+  foreach(NAME ${ARGN})
+    add_test(
+      NAME ${NAME}
+      COMMAND ${CMAKE_COMMAND}
+        -B ${CMAKE_CURRENT_BINARY_DIR}
+        -D CMAKE_MODULE_PATH=${CMAKE_MODULE_PATH}
+        -D TEST_MATCHES="^${NAME}$"
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/${FILE}
+    )
+  endforeach()
+endfunction()
 
-add_test(
-  NAME "Create directory recursively"
-  COMMAND cmake ${ARGS} -P ${CMAKE_CURRENT_SOURCE_DIR}/MkdirRecursiveTest.cmake
+add_cmake_test(
+  MkdirRecursiveTest.cmake
+  "Create directory recursively"
 )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,6 @@
+list(APPEND ARGS -B ${CMAKE_CURRENT_BINARY_DIR} -D CMAKE_MODULE_PATH=${CMAKE_MODULE_PATH})
+
+add_test(
+  NAME MkdirRecursiveTest
+  COMMAND cmake ${ARGS} -P ${CMAKE_CURRENT_SOURCE_DIR}/MkdirRecursiveTest.cmake
+)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 list(APPEND ARGS -B ${CMAKE_CURRENT_BINARY_DIR} -D CMAKE_MODULE_PATH=${CMAKE_MODULE_PATH})
 
 add_test(
-  NAME MkdirRecursiveTest
+  NAME "Create directory recursively"
   COMMAND cmake ${ARGS} -P ${CMAKE_CURRENT_SOURCE_DIR}/MkdirRecursiveTest.cmake
 )

--- a/test/MkdirRecursiveTest.cmake
+++ b/test/MkdirRecursiveTest.cmake
@@ -1,12 +1,16 @@
 if(EXISTS ${CMAKE_CURRENT_BINARY_DIR}/parent)
+  message(STATUS "Removing test directory")
   file(REMOVE_RECURSE ${CMAKE_CURRENT_BINARY_DIR}/parent)
 endif()
 
 include(MkdirRecursive)
+
+message(STATUS "Creating test directory recursively")
 mkdir_recursive(${CMAKE_CURRENT_BINARY_DIR}/parent/child)
 
-if(EXISTS ${CMAKE_CURRENT_BINARY_DIR}/parent/child)
-  file(REMOVE_RECURSE ${CMAKE_CURRENT_BINARY_DIR}/parent)
-else()
+if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/parent/child)
   message(FATAL_ERROR "Directory `${CMAKE_CURRENT_BINARY_DIR}/parent/child` should exist!")
 endif()
+
+message(STATUS "Removing test directory")
+file(REMOVE_RECURSE ${CMAKE_CURRENT_BINARY_DIR}/parent)

--- a/test/MkdirRecursiveTest.cmake
+++ b/test/MkdirRecursiveTest.cmake
@@ -1,16 +1,23 @@
-if(EXISTS ${CMAKE_CURRENT_BINARY_DIR}/parent)
+# Matches everything if not defined
+if(NOT TEST_MATCHES)
+  set(TEST_MATCHES ".*")
+endif()
+
+if("Create directory recursively" MATCHES ${TEST_MATCHES})
+  if(EXISTS ${CMAKE_CURRENT_BINARY_DIR}/parent)
+    message(STATUS "Removing test directory")
+    file(REMOVE_RECURSE ${CMAKE_CURRENT_BINARY_DIR}/parent)
+  endif()
+
+  include(MkdirRecursive)
+
+  message(STATUS "Creating test directory recursively")
+  mkdir_recursive(${CMAKE_CURRENT_BINARY_DIR}/parent/child)
+
+  if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/parent/child)
+    message(FATAL_ERROR "Directory `${CMAKE_CURRENT_BINARY_DIR}/parent/child` should exist!")
+  endif()
+
   message(STATUS "Removing test directory")
   file(REMOVE_RECURSE ${CMAKE_CURRENT_BINARY_DIR}/parent)
 endif()
-
-include(MkdirRecursive)
-
-message(STATUS "Creating test directory recursively")
-mkdir_recursive(${CMAKE_CURRENT_BINARY_DIR}/parent/child)
-
-if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/parent/child)
-  message(FATAL_ERROR "Directory `${CMAKE_CURRENT_BINARY_DIR}/parent/child` should exist!")
-endif()
-
-message(STATUS "Removing test directory")
-file(REMOVE_RECURSE ${CMAKE_CURRENT_BINARY_DIR}/parent)

--- a/test/MkdirRecursiveTest.cmake
+++ b/test/MkdirRecursiveTest.cmake
@@ -21,3 +21,8 @@ if("Create directory recursively" MATCHES ${TEST_MATCHES})
   message(STATUS "Removing test directory")
   file(REMOVE_RECURSE ${CMAKE_CURRENT_BINARY_DIR}/parent)
 endif()
+
+# Add more test cases here.
+if("Test name" MATCHES ${TEST_MATCHES})
+  # Do something.
+endif()


### PR DESCRIPTION
This pull request resolves #19 by implementing the following changes:
- Moves sample testing declarations to be under `test/CMakeLists.txt`.
- Enhances status messages for the sample `mkdir_recursive` function during testing.
- Implements a more descriptive naming convention for testing, requiring [CMP0110](https://cmake.org/cmake/help/latest/policy/CMP0110.html), available in CMake version 3.19.
- Introduces support for testing multiple test cases in a single file.
- Adds comments to guide the addition of more test cases.