### PR TITLE
Modify Testing to Not Pass Build Directory

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,7 +3,6 @@ function(add_cmake_test FILE)
     add_test(
       NAME ${NAME}
       COMMAND ${CMAKE_COMMAND}
-        -B ${CMAKE_CURRENT_BINARY_DIR}
         -D CMAKE_MODULE_PATH=${CMAKE_MODULE_PATH}
         -D TEST_MATCHES="^${NAME}$"
         -P ${CMAKE_CURRENT_SOURCE_DIR}/${FILE}

--- a/test/MkdirRecursiveTest.cmake
+++ b/test/MkdirRecursiveTest.cmake
@@ -4,22 +4,22 @@ if(NOT TEST_MATCHES)
 endif()
 
 if("Create directory recursively" MATCHES ${TEST_MATCHES})
-  if(EXISTS ${CMAKE_CURRENT_BINARY_DIR}/parent)
+  if(EXISTS parent)
     message(STATUS "Removing test directory")
-    file(REMOVE_RECURSE ${CMAKE_CURRENT_BINARY_DIR}/parent)
+    file(REMOVE_RECURSE parent)
   endif()
 
   include(MkdirRecursive)
 
   message(STATUS "Creating test directory recursively")
-  mkdir_recursive(${CMAKE_CURRENT_BINARY_DIR}/parent/child)
+  mkdir_recursive(parent/child)
 
-  if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/parent/child)
-    message(FATAL_ERROR "Directory `${CMAKE_CURRENT_BINARY_DIR}/parent/child` should exist!")
+  if(NOT EXISTS parent/child)
+    message(FATAL_ERROR "Directory `parent/child` should exist!")
   endif()
 
   message(STATUS "Removing test directory")
-  file(REMOVE_RECURSE ${CMAKE_CURRENT_BINARY_DIR}/parent)
+  file(REMOVE_RECURSE parent)
 endif()
 
 # Add more test cases here.


### PR DESCRIPTION
This pull request simply modifies the sample testing to not pass the `CMAKE_CURRENT_BINARY_DIR` when invoking test scripts. This change is proposed because the build directory will rarely be required by other CMake modules for testing. Therefore, it's better to removes it to simplify this template.