### PR TITLE
Assert If There's Nothing to Test

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,7 +4,7 @@ function(add_cmake_test FILE)
       NAME ${NAME}
       COMMAND ${CMAKE_COMMAND}
         -D CMAKE_MODULE_PATH=${CMAKE_MODULE_PATH}
-        -D TEST_MATCHES="^${NAME}$"
+        -D TEST_MATCHES=^${NAME}$
         -P ${CMAKE_CURRENT_SOURCE_DIR}/${FILE}
     )
   endforeach()

--- a/test/MkdirRecursiveTest.cmake
+++ b/test/MkdirRecursiveTest.cmake
@@ -3,7 +3,11 @@ if(NOT TEST_MATCHES)
   set(TEST_MATCHES ".*")
 endif()
 
+set(TEST_COUNT 0)
+
 if("Create directory recursively" MATCHES ${TEST_MATCHES})
+  math(EXPR TEST_COUNT "${TEST_COUNT} + 1")
+
   if(EXISTS parent)
     message(STATUS "Removing test directory")
     file(REMOVE_RECURSE parent)
@@ -24,5 +28,11 @@ endif()
 
 # Add more test cases here.
 if("Test name" MATCHES ${TEST_MATCHES})
+  math(EXPR TEST_COUNT "${TEST_COUNT} + 1")
+
   # Do something.
+endif()
+
+if(TEST_COUNT LESS_EQUAL 0)
+  message(FATAL_ERROR "Nothing to test with: ${TEST_MATCHES}")
 endif()


### PR DESCRIPTION
This pull request resolves #28 by introducing the following changes:
- Adds an assertion to check if there's nothing to test with the given `TEST_MATCHES` option.
- Fixes the regex for the `TEST_MATCHES` option, preventing cases where nothing is tested.