### PR TITLE
Allow Spaces in Test Function Names

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,12 +1,10 @@
 function(add_cmake_test FILE)
   foreach(NAME ${ARGN})
-    string(TOLOWER "${NAME}" TEST_COMMAND)
-    string(REPLACE " " "_" TEST_COMMAND "${TEST_COMMAND}")
     add_test(
       NAME "${NAME}"
       COMMAND "${CMAKE_COMMAND}"
         -D CMAKE_MODULE_PATH=${CMAKE_MODULE_PATH}
-        -D TEST_COMMAND=${TEST_COMMAND}
+        -D TEST_COMMAND=${NAME}
         -P ${CMAKE_CURRENT_SOURCE_DIR}/${FILE}
     )
   endforeach()

--- a/test/cmake/MkdirRecursiveTest.cmake
+++ b/test/cmake/MkdirRecursiveTest.cmake
@@ -1,4 +1,4 @@
-function(test_create_directory_recursively)
+function("Create directory recursively")
   if(EXISTS parent)
     message(STATUS "Removing test directory")
     file(REMOVE_RECURSE parent)
@@ -18,14 +18,14 @@ function(test_create_directory_recursively)
 endfunction()
 
 # Add more test cases here.
-function(test_something)
+function("Test something")
   # Do something.
 endfunction()
 
 if(NOT DEFINED TEST_COMMAND)
   message(FATAL_ERROR "The 'TEST_COMMAND' variable should be defined")
-elseif(NOT COMMAND test_${TEST_COMMAND})
-  message(FATAL_ERROR "Unable to find a command named 'test_${TEST_COMMAND}'")
+elseif(NOT COMMAND "${TEST_COMMAND}")
+  message(FATAL_ERROR "Unable to find a command named '${TEST_COMMAND}'")
 endif()
 
-cmake_language(CALL test_${TEST_COMMAND})
+cmake_language(CALL "${TEST_COMMAND}")

--- a/test/cmake/MkdirRecursiveTest.cmake
+++ b/test/cmake/MkdirRecursiveTest.cmake
@@ -22,10 +22,4 @@ function("Test something")
   # Do something.
 endfunction()
 
-if(NOT DEFINED TEST_COMMAND)
-  message(FATAL_ERROR "The 'TEST_COMMAND' variable should be defined")
-elseif(NOT COMMAND "${TEST_COMMAND}")
-  message(FATAL_ERROR "Unable to find a command named '${TEST_COMMAND}'")
-endif()
-
 cmake_language(CALL "${TEST_COMMAND}")


### PR DESCRIPTION
This pull request resolves #53 by allowing spaces in the test function names, enabling the test function to have the same name as the test name. This change also removes unnecessary if guards before calling the test command.