### PR TITLE
Simplify Sample Testing

### DIFF
--- a/test/cmake/MkdirRecursiveTest.cmake
+++ b/test/cmake/MkdirRecursiveTest.cmake
@@ -1,20 +1,13 @@
+include(MkdirRecursive)
+
 function("Create directory recursively")
-  if(EXISTS parent)
-    message(STATUS "Removing test directory")
-    file(REMOVE_RECURSE parent)
-  endif()
+  file(REMOVE_RECURSE parent)
 
-  include(MkdirRecursive)
-
-  message(STATUS "Creating test directory recursively")
   mkdir_recursive(parent/child)
 
   if(NOT EXISTS parent/child)
-    message(FATAL_ERROR "Directory `parent/child` should exist!")
+    message(FATAL_ERROR "expected path 'parent/child' to exist")
   endif()
-
-  message(STATUS "Removing test directory")
-  file(REMOVE_RECURSE parent)
 endfunction()
 
 # Add more test cases here.


### PR DESCRIPTION
This pull request resolves #57 by simplifying the sample testing in the `MkdirRecursiveTest.cmake` module.