### PR TITLE
Specify CMake Minimum Version in Test Modules

### DIFF
--- a/test/cmake/MkdirRecursiveTest.cmake
+++ b/test/cmake/MkdirRecursiveTest.cmake
@@ -1,3 +1,5 @@
+cmake_minimum_required(VERSION 3.5)
+
 include(MkdirRecursive)
 
 function("Create directory recursively")


### PR DESCRIPTION
This pull request resolves #59 by simply specifying the CMake minimum required version in the test modules.