### PR TITLE
Always Enable Installation Target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,23 +10,21 @@ project(
 
 include(cmake/MkdirRecursive.cmake)
 
-if(PROJECT_IS_TOP_LEVEL)
-  if(BUILD_TESTING)
-    enable_testing()
-    add_subdirectory(test)
-  endif()
-
-  include(CMakePackageConfigHelpers)
-  write_basic_package_version_file(
-    MyMkdirConfigVersion.cmake
-    COMPATIBILITY SameMajorVersion
-  )
-
-  install(
-    FILES
-      cmake/MkdirRecursive.cmake
-      cmake/MyMkdirConfig.cmake
-      ${CMAKE_CURRENT_BINARY_DIR}/MyMkdirConfigVersion.cmake
-    DESTINATION lib/cmake/MyMkdir
-  )
+if(PROJECT_IS_TOP_LEVEL AND BUILD_TESTING)
+  enable_testing()
+  add_subdirectory(test)
 endif()
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+  MyMkdirConfigVersion.cmake
+  COMPATIBILITY SameMajorVersion
+)
+
+install(
+  FILES
+    cmake/MkdirRecursive.cmake
+    cmake/MyMkdirConfig.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/MyMkdirConfigVersion.cmake
+  DESTINATION lib/cmake/MyMkdir
+)


### PR DESCRIPTION
This pull request resolves #70 by modifying the top-level `CMakeLists.txt` to always enable installation targets.