### PR TITLE
Add Option to Enable Test Targets

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Configure Project
         uses: threeal/cmake-action@v1.3.0
         with:
-          options: BUILD_TESTING=ON
+          options: MY_MKDIR_ENABLE_TESTS=ON
 
       - name: Test Project
         uses: threeal/ctest-action@v1.0.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,13 +8,14 @@ project(
   LANGUAGES NONE
 )
 
+option(MY_MKDIR_ENABLE_TESTS "Enable test targets.")
 option(
   MY_MKDIR_ENABLE_INSTALL "Enable install targets." ${PROJECT_IS_TOP_LEVEL}
 )
 
 include(cmake/MkdirRecursive.cmake)
 
-if(PROJECT_IS_TOP_LEVEL AND BUILD_TESTING)
+if(MY_MKDIR_ENABLE_TESTS)
   enable_testing()
 
   add_test(


### PR DESCRIPTION
This pull request resolves #76 by adding a `MY_MKDIR_ENABLE_TESTS` option to enable test targets in the sample project, replacing the `BUILD_TESTING` variable.