### PR TITLE
Utilize Assertion.cmake Module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,11 @@ include(cmake/MkdirRecursive.cmake)
 if(MY_MKDIR_ENABLE_TESTS)
   enable_testing()
 
+  file(
+    DOWNLOAD https://threeal.github.io/assertion-cmake/v0.3.0
+      ${CMAKE_BINARY_DIR}/Assertion.cmake
+    EXPECTED_MD5 851f49c10934d715df5d0b59c8b8c72a)
+
   add_test(
     NAME "recursive directory creation"
     COMMAND "${CMAKE_COMMAND}"

--- a/test/MkdirRecursive.cmake
+++ b/test/MkdirRecursive.cmake
@@ -1,11 +1,9 @@
 cmake_minimum_required(VERSION 3.5)
 
 find_package(MyMkdir REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../cmake)
+include(Assertion.cmake)
 
 file(REMOVE_RECURSE parent)
 
 mkdir_recursive(parent/child)
-
-if(NOT EXISTS parent/child)
-  message(FATAL_ERROR "expected path 'parent/child' to exist")
-endif()
+assert(EXISTS parent/child)


### PR DESCRIPTION
This pull request resolves #80 by utilizing the [Assertion.cmake](https://github.com/threeal/assertion-cmake/) module for asserting conditions during the sample project testing.