### PR TITLE
Fix Tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ if(MY_MKDIR_ENABLE_TESTS)
   add_test(
     NAME "recursive directory creation"
     COMMAND "${CMAKE_COMMAND}"
-      -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/MkdirRecursive.cmake)
+      -P ${CMAKE_CURRENT_SOURCE_DIR}/test/MkdirRecursive.cmake)
 endif()
 
 if(MY_MKDIR_ENABLE_INSTALL)

--- a/test/MkdirRecursive.cmake
+++ b/test/MkdirRecursive.cmake
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 
-find_package(MyMkdir REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../../cmake)
+find_package(MyMkdir REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../cmake)
 
 file(REMOVE_RECURSE parent)
 


### PR DESCRIPTION
This pull request simply fixes tests that were not running properly due to executing the wrong module. It also corrects the `test/MkdirRecursive.cmake` file to find the MyMkdir package in the correct location.