### PR TITLE
Bump Assertion.cmake to Version 1.3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,9 +17,9 @@ if(MY_MKDIR_ENABLE_TESTS)
   enable_testing()
 
   file(
-    DOWNLOAD https://threeal.github.io/assertion-cmake/v0.3.0
+    DOWNLOAD https://github.com/threeal/assertion-cmake/releases/download/v1.0.0/Assertion.cmake
       ${CMAKE_BINARY_DIR}/Assertion.cmake
-    EXPECTED_MD5 851f49c10934d715df5d0b59c8b8c72a)
+    EXPECTED_MD5 1d8ec589d6cc15772581bf77eb3873ff)
 
   add_test(
     NAME "recursive directory creation"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,11 +20,10 @@ if(MY_MKDIR_ENABLE_TESTS)
     DOWNLOAD https://github.com/threeal/assertion-cmake/releases/download/v1.0.0/Assertion.cmake
       ${CMAKE_BINARY_DIR}/Assertion.cmake
     EXPECTED_MD5 1d8ec589d6cc15772581bf77eb3873ff)
+  include(${CMAKE_BINARY_DIR}/Assertion.cmake)
 
-  add_test(
-    NAME "recursive directory creation"
-    COMMAND "${CMAKE_COMMAND}"
-      -P ${CMAKE_CURRENT_SOURCE_DIR}/test/MkdirRecursive.cmake)
+  assertion_add_test(test/MkdirRecursive.cmake
+    NAME "recursive directory creation")
 endif()
 
 if(MY_MKDIR_ENABLE_INSTALL)

--- a/test/MkdirRecursive.cmake
+++ b/test/MkdirRecursive.cmake
@@ -1,7 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
-
 find_package(MyMkdir REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../cmake)
-include(Assertion.cmake)
 
 file(REMOVE_RECURSE parent)
 


### PR DESCRIPTION
This pull request bumps the [Assertion.cmake](https://github.com/threeal/assertion-cmake) module to version [1.3.0](https://github.com/threeal/assertion-cmake/releases/tag/v1.3.0). It also updates the sample project to utilize the `assertion_add_test` function to declare a CMake test.