### PR TITLE
Remove Include Guard in Sample Module

### DIFF
--- a/cmake/MkdirRecursive.cmake
+++ b/cmake/MkdirRecursive.cmake
@@ -1,5 +1,3 @@
-include_guard(GLOBAL)
-
 function(mkdir_recursive DIR_PATH)
   file(MAKE_DIRECTORY "${DIR_PATH}")
 endfunction()


### PR DESCRIPTION
This pull request resolves #98 by removing the call to `include_guard` in the sample `MyMkdir.cmake` module, allowing the sample module to be included multiple times.