### PR TITLE
Flexible Dependencies Download

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,10 +8,10 @@ project(
   LANGUAGES NONE)
 
 option(MY_MKDIR_ENABLE_TESTS "Enable test targets.")
-option(
-  MY_MKDIR_ENABLE_INSTALL "Enable install targets." ${PROJECT_IS_TOP_LEVEL})
+option(MY_MKDIR_ENABLE_INSTALL "Enable install targets." "${PROJECT_IS_TOP_LEVEL}")
 
-include(cmake/MkdirRecursive.cmake)
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+include(MkdirRecursive)
 
 if(MY_MKDIR_ENABLE_TESTS)
   enable_testing()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,12 +16,7 @@ include(MkdirRecursive)
 if(MY_MKDIR_ENABLE_TESTS)
   enable_testing()
 
-  file(
-    DOWNLOAD https://github.com/threeal/assertion-cmake/releases/download/v1.0.0/Assertion.cmake
-      ${CMAKE_BINARY_DIR}/Assertion.cmake
-    EXPECTED_MD5 1d8ec589d6cc15772581bf77eb3873ff)
-  include(${CMAKE_BINARY_DIR}/Assertion.cmake)
-
+  find_package(Assertion 1.0.0 REQUIRED)
   assertion_add_test(test/mkdir_recursive.cmake)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,11 @@ project(
 option(MY_MKDIR_ENABLE_TESTS "Enable test targets.")
 option(MY_MKDIR_ENABLE_INSTALL "Enable install targets." "${PROJECT_IS_TOP_LEVEL}")
 
+# Prefer system packages over the find modules provided by this project.
+if(NOT DEFINED CMAKE_FIND_PACKAGE_PREFER_CONFIG)
+  set(CMAKE_FIND_PACKAGE_PREFER_CONFIG TRUE)
+endif()
+
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 include(MkdirRecursive)
 

--- a/cmake/FindAssertion.cmake
+++ b/cmake/FindAssertion.cmake
@@ -1,0 +1,8 @@
+file(
+  DOWNLOAD https://github.com/threeal/assertion-cmake/releases/download/v1.0.0/Assertion.cmake
+    ${CMAKE_BINARY_DIR}/cmake/Assertion.cmake
+  EXPECTED_MD5 1d8ec589d6cc15772581bf77eb3873ff)
+include(${CMAKE_BINARY_DIR}/cmake/Assertion.cmake)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Assertion REQUIRED_VARS ASSERTION_LIST_FILE)


### PR DESCRIPTION
This pull request resolves #100 by modifying the dependencies of the sample project (the [Assertion.cmake](https://github.com/threeal/assertion-cmake/) module) to be downloaded flexibly. This is achieved by adding a new `FindAssertion.cmake` module, which serves as a fallback to download the `Assertion.cmake` module if it is not available on the system and include it in the sample project.

It also modifies the sample project by appending the `cmake` directory to the [`CMAKE_MODULE_PATH`](https://cmake.org/cmake/help/latest/variable/CMAKE_MODULE_PATH.html) variable and enabling the [`CMAKE_FIND_PACKAGE_PREFER_CONFIG`](https://cmake.org/cmake/help/latest/variable/CMAKE_FIND_PACKAGE_PREFER_CONFIG.html) variable.