### PR TITLE
Improve Module Inclusion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,13 +10,15 @@ project(
 option(MY_PROJECT_ENABLE_TESTS "Enable test targets.")
 option(MY_PROJECT_ENABLE_INSTALL "Enable install targets." "${PROJECT_IS_TOP_LEVEL}")
 
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+
 # Prefer system packages over the find modules provided by this project.
 if(NOT DEFINED CMAKE_FIND_PACKAGE_PREFER_CONFIG)
   set(CMAKE_FIND_PACKAGE_PREFER_CONFIG TRUE)
 endif()
 
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
-include(MyProject)
+# Include the main module.
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/MyProject.cmake)
 
 if(MY_PROJECT_ENABLE_TESTS)
   enable_testing()

--- a/test/git_clone.cmake
+++ b/test/git_clone.cmake
@@ -1,4 +1,4 @@
-find_package(MyProject REQUIRED PATHS ${CMAKE_CURRENT_LIST_DIR}/../cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/../cmake/MyProject.cmake)
 
 section("it should clone a Git repository")
   file(REMOVE_RECURSE repo)


### PR DESCRIPTION
This pull request resolves #108 by introducing the following changes:
- Include the `MyProject.cmake` module using the relative path in the `CMakeLists.txt` file.
- Include the `MyProject.cmake` module directly in the test files.