### PR TITLE
Improve Installation Configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,11 +30,11 @@ endif()
 if(MY_PROJECT_ENABLE_INSTALL)
   include(CMakePackageConfigHelpers)
   write_basic_package_version_file(
-    MyProjectConfigVersion.cmake COMPATIBILITY SameMajorVersion)
+    cmake/MyProjectConfigVersion.cmake COMPATIBILITY SameMajorVersion)
 
   install(
     FILES cmake/MyProject.cmake
       cmake/MyProjectConfig.cmake
-      ${CMAKE_CURRENT_BINARY_DIR}/MyProjectConfigVersion.cmake
+      ${CMAKE_CURRENT_BINARY_DIR}/cmake/MyProjectConfigVersion.cmake
     DESTINATION lib/cmake/MyProject)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,8 +29,8 @@ endif()
 
 if(MY_PROJECT_ENABLE_INSTALL)
   include(CMakePackageConfigHelpers)
-  write_basic_package_version_file(
-    cmake/MyProjectConfigVersion.cmake COMPATIBILITY SameMajorVersion)
+  write_basic_package_version_file(cmake/MyProjectConfigVersion.cmake
+    COMPATIBILITY SameMajorVersion ARCH_INDEPENDENT)
 
   install(
     FILES cmake/MyProject.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,9 +32,10 @@ if(MY_PROJECT_ENABLE_INSTALL)
   write_basic_package_version_file(cmake/MyProjectConfigVersion.cmake
     COMPATIBILITY SameMajorVersion ARCH_INDEPENDENT)
 
+  include(GNUInstallDirs)
   install(
     FILES cmake/MyProject.cmake
       cmake/MyProjectConfig.cmake
       ${CMAKE_CURRENT_BINARY_DIR}/cmake/MyProjectConfigVersion.cmake
-    DESTINATION lib/cmake/MyProject)
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/MyProject)
 endif()


### PR DESCRIPTION
This pull request resolves #110 by improving the installation configuration as follows:
- Modifies the package version file to be generated under the `cmake` directory with the `ARCH_INDEPENDENT` option.
- Updates the installation of modules to use the directory specified by the `CMAKE_INSTALL_LIBDIR` variable.