### PR TITLE
Fix Unable to Determine Install Library Directory Warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,10 +40,9 @@ if(MY_PROJECT_ENABLE_INSTALL)
 
   # TODO: Replace the `FILES` arguments with the correct files.
   # TODO: Rename the `DESTINATION` argument to match the correct project name.
-  include(GNUInstallDirs)
   install(
     FILES cmake/MyProject.cmake
       cmake/MyProjectConfig.cmake
       ${CMAKE_CURRENT_BINARY_DIR}/cmake/MyProjectConfigVersion.cmake
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/MyProject)
+    DESTINATION lib/cmake/MyProject)
 endif()


### PR DESCRIPTION
This pull request resolves #114 by replacing the `CMAKE_INSTALL_LIBDIR` variable from the [`GNUInstallDirs`](https://cmake.org/cmake/help/v3.21/module/GNUInstallDirs.html) module with the string `lib`.