### PR TITLE
Generate Package Config File During Build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,11 @@ endif()
 # TODO: Replace `MY_PROJECT_ENABLE_INSTALL` with the correct option.
 if(MY_PROJECT_ENABLE_INSTALL)
   # TODO: Rename the output file to be prefixed with the correct project name.
+  # TODO: Replace `MyProject.cmake` with the correct main module file.
+  file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/cmake/MyProjectConfig.cmake
+    "include(\${CMAKE_CURRENT_LIST_DIR}/MyProject.cmake)\n")
+
+  # TODO: Rename the output file to be prefixed with the correct project name.
   include(CMakePackageConfigHelpers)
   write_basic_package_version_file(cmake/MyProjectConfigVersion.cmake
     COMPATIBILITY SameMajorVersion ARCH_INDEPENDENT)
@@ -42,7 +47,7 @@ if(MY_PROJECT_ENABLE_INSTALL)
   # TODO: Rename the `DESTINATION` argument to match the correct project name.
   install(
     FILES cmake/MyProject.cmake
-      cmake/MyProjectConfig.cmake
+      ${CMAKE_CURRENT_BINARY_DIR}/cmake/MyProjectConfig.cmake
       ${CMAKE_CURRENT_BINARY_DIR}/cmake/MyProjectConfigVersion.cmake
     DESTINATION lib/cmake/MyProject)
 endif()

--- a/README.md
+++ b/README.md
@@ -35,15 +35,13 @@ Alternatively, you can also remove the `LICENSE` file or leave it as is to mark 
 Do the following steps to replace all the sample information from the template with the new project information:
 - Replace the content of this `README.md` file with the description of the new project. Refer to [this documentation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-readmes) for more information about adding READMEs to a project.
 - Rename the main module file ([`cmake/MyProject.cmake`](./cmake/MyProject.cmake)) to match the correct project name.
-- Modify the package config file ([`cmake/MyProjectConfig.cmake`](./cmake/MyProjectConfig.cmake)) as follows:
-  - Rename the file to match the correct project name.
-  - Modify the content to include the correct main module file.
 - Modify the test files ([`test/git_clone.cmake`](./test/git_clone.cmake)) to include the correct main module file.
 - Modify the [`CMakeLists.txt`](./CMakeLists.txt) file as follows:
   - Replace the project name, version, description, and homepage URL.
   - Rename the options to be prefixed with the correct project name.
   - Modify to include the correct main module file.
-  - Rename the package version file to be prefixed with the correct project name.
+  - Rename the package config file to be prefixed with the correct project name and modify it to include the correct main module file.
+  - Rename the package config version file to be prefixed with the correct project name.
   - Modify to install the correct files to the correct destination.
 - Modify workflow files as follows:
   - Use the correct project name in the [`build.yaml`](./.github/workflows/build.yaml) workflow file.
@@ -55,7 +53,7 @@ Do the following steps to replace all the sample information from the template w
 
 Modify the contents of the main module file ([`cmake/MyProject.cmake`](./cmake/MyProject.cmake)) with variables or functions provided by the new CMake project. If you are new to CMake, refer to [this documentation](https://cmake.org/cmake/help/v3.21/index.html) for more information about CMake.
 
-More module files can also be added under the [`cmake`](./cmake) directory. Just make sure to add the new module files to the include list and install list in the [`CMakeLists.txt`](./CMakeLists.txt) file and the package config file ([`cmake/MyProjectConfig.cmake`](./cmake/MyProjectConfig.cmake)).
+Additional module files can be added under the [`cmake`](./cmake) directory. Just ensure the new module files are included in the build and install lists in the [`CMakeLists.txt`](./CMakeLists.txt) file.
 
 After writing the module files, you can build the project using the following command:
 

--- a/cmake/MyProjectConfig.cmake
+++ b/cmake/MyProjectConfig.cmake
@@ -1,4 +1,0 @@
-# TODO: Rename this module to match the correct project name.
-
-# TODO: Replace `MyProject.cmake` with the correct main module file.
-include(${CMAKE_CURRENT_LIST_DIR}/MyProject.cmake)


### PR DESCRIPTION
This pull request resolves #122 by modifying the `MyProjectConfig.cmake` file to be generated during the build process instead of being committed to the source files. It also updates the guide in the `README.md` file accordingly.