### PR TITLE
Add CMake Preset for Development

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,9 +13,7 @@ jobs:
         uses: actions/checkout@v4.2.1
 
       - name: Configure Project
-        uses: threeal/cmake-action@v2.0.0
-        with:
-          run-build: false
+        run: cmake --preset default
 
       - name: Install Project
         run: cmake --install build --prefix install

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,13 +13,7 @@ jobs:
         uses: actions/checkout@v4.2.1
 
       - name: Configure Project
-        uses: threeal/cmake-action@v2.0.0
-        with:
-          # TODO: Replace `MY_PROJECT_ENABLE_TESTS` with the correct test option.
-          options: MY_PROJECT_ENABLE_TESTS=ON
-          run-build: false
+        run: cmake --preset development
 
       - name: Test Project
-        uses: threeal/ctest-action@v1.1.0
-        with:
-          verbose: true
+        run: ctest --preset development

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,32 @@
+{
+  "version": 3,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 21
+  },
+  "configurePresets": [
+    {
+      "name": "default",
+      "binaryDir": "${sourceDir}/build"
+    },
+    {
+      "name": "development",
+      "inherits": ["default"],
+      "cacheVariables": {
+        "MY_PROJECT_ENABLE_TESTS": "ON"
+      }
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "development",
+      "configurePreset": "development",
+      "output": {
+        "verbosity": "verbose"
+      },
+      "execution": {
+        "noTestsAction": "error"
+      }
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ Do the following steps to replace all the sample information from the template w
   - Rename the options to be prefixed with the correct project name.
 - Modify workflow files as follows:
   - Use the correct project name in the [`build.yaml`](./.github/workflows/build.yaml) workflow file.
-  - Use the correct options in the [`test.yaml`](./.github/workflows/test.yaml) workflow file.
 
 > Note: You can also search for the `TODO` comments for a list of information that needs to be replaced.
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Do the following steps to replace all the sample information from the template w
   - Rename the package config file to be prefixed with the correct project name and modify it to include the correct main module file.
   - Rename the package config version file to be prefixed with the correct project name.
   - Modify to install the correct files to the correct destination.
+- Modify the [`CMakePresets.json`](./CMakePresets.json) file as follows:
+  - Rename the options to be prefixed with the correct project name.
 - Modify workflow files as follows:
   - Use the correct project name in the [`build.yaml`](./.github/workflows/build.yaml) workflow file.
   - Use the correct options in the [`test.yaml`](./.github/workflows/test.yaml) workflow file.
@@ -58,7 +60,7 @@ Additional module files can be added under the [`cmake`](./cmake) directory. Jus
 After writing the module files, you can build the project using the following command:
 
 ```sh
-cmake -B build
+cmake --preset default
 ```
 
 ### Testing Modules
@@ -70,11 +72,9 @@ More test files can also be added under the [`test`](./test) directory. Just mak
 After writing the test files, you can test the project using the following command:
 
 ```sh
-cmake -B build -D MY_PROJECT_ENABLE_TESTS=ON
-ctest --test-dir build --output-on-failure
+cmake --preset development
+ctest --preset development
 ```
-
-> Note: Replace the `MY_PROJECT_ENABLE_TESTS` option with the correct test option.
 
 ### Cut a Release
 


### PR DESCRIPTION
This pull request resolves #126 by adding a new `CMakePresets.json` file that includes configuration and test presets for development. It also updates the CI workflows to utilize these presets and revises the documentation accordingly.