### PR TITLE
Add CPack Support

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,14 +15,12 @@ jobs:
       - name: Configure Project
         run: cmake --preset default
 
-      - name: Install Project
-        run: cmake --install build --prefix install
+      - name: Package Project
+        run: cpack --preset default
 
       - name: Upload Project
         uses: actions/upload-artifact@v4.4.3
         with:
-          # TODO: Replace `MyProject` with the correct project name.
-          name: MyProject
-          path: install
+          path: build/*.tar.gz
           if-no-files-found: error
           overwrite: true

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 !.git*
 
 build
-install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,4 +50,7 @@ if(MY_PROJECT_ENABLE_INSTALL)
       ${CMAKE_CURRENT_BINARY_DIR}/cmake/MyProjectConfig.cmake
       ${CMAKE_CURRENT_BINARY_DIR}/cmake/MyProjectConfigVersion.cmake
     DESTINATION lib/cmake/MyProject)
+
+  set(CPACK_SYSTEM_NAME any)
+  include(CPack)
 endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,8 +1,8 @@
 {
-  "version": 3,
+  "version": 6,
   "cmakeMinimumRequired": {
     "major": 3,
-    "minor": 21
+    "minor": 25
   },
   "configurePresets": [
     {
@@ -27,6 +27,13 @@
       "execution": {
         "noTestsAction": "error"
       }
+    }
+  ],
+  "packagePresets": [
+    {
+      "name": "default",
+      "configurePreset": "default",
+      "generators": ["TGZ"]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -77,10 +77,10 @@ ctest --preset development
 
 ### Cut a Release
 
-When everything is complete, run the following command to install the new project to the `install` directory:
+When everything is complete, run the following command to package the project:
 
 ```sh
-cmake --install build --prefix install
+cpack --preset default
 ```
 
-Files inside the `install` directory can be included in the release files. Before releasing, ensure that this project is at the correct version and pushed to the upstream repository. Refer to [this documentation](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases) for more information about releasing a project.
+The project will be packaged into the `build/*.tar.gz` file, which can be included in the release files. Before releasing, ensure that this project is at the correct version and has been pushed to the upstream repository. Refer to [this documentation](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases) for more information about releasing a project.

--- a/README.md
+++ b/README.md
@@ -45,8 +45,6 @@ Do the following steps to replace all the sample information from the template w
   - Modify to install the correct files to the correct destination.
 - Modify the [`CMakePresets.json`](./CMakePresets.json) file as follows:
   - Rename the options to be prefixed with the correct project name.
-- Modify workflow files as follows:
-  - Use the correct project name in the [`build.yaml`](./.github/workflows/build.yaml) workflow file.
 
 > Note: You can also search for the `TODO` comments for a list of information that needs to be replaced.
 


### PR DESCRIPTION
This pull request resolves #128 by adding CPack support to the project, which includes a new `default` package preset and updates the workflow to package the project instead of installing it. It also removes the `install` directory from the Git ignore list and updates the documentation accordingly.