### PR TITLE
Bump Assertion.cmake to Version 2.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,8 +27,10 @@ include(cmake/MyProject.cmake)
 if(MY_PROJECT_ENABLE_TESTS)
   enable_testing()
 
-  find_package(Assertion 1.0.0 REQUIRED)
-  assertion_add_test(test/test_git_clone.cmake)
+  find_package(Assertion 2.0.0 REQUIRED)
+  list(APPEND CMAKE_SCRIPT_TEST_DEFINITIONS CMAKE_MODULE_PATH)
+
+  add_cmake_script_test(test/test_git_clone.cmake)
 endif()
 
 # TODO: Replace `MY_PROJECT_ENABLE_INSTALL` with the correct option.

--- a/cmake/FindAssertion.cmake
+++ b/cmake/FindAssertion.cmake
@@ -1,8 +1,11 @@
 file(
-  DOWNLOAD https://github.com/threeal/assertion-cmake/releases/download/v1.0.0/Assertion.cmake
+  DOWNLOAD https://github.com/threeal/assertion-cmake/releases/download/v2.0.0/Assertion.cmake
     ${CMAKE_BINARY_DIR}/cmake/Assertion.cmake
-  EXPECTED_MD5 1d8ec589d6cc15772581bf77eb3873ff)
+  EXPECTED_MD5 5ebe475aee6fc5660633152f815ce9f6)
 include(${CMAKE_BINARY_DIR}/cmake/Assertion.cmake)
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(Assertion REQUIRED_VARS ASSERTION_LIST_FILE)
+find_package_handle_standard_args(
+  Assertion REQUIRED_VARS ASSERTION_VERSION VERSION_VAR ASSERTION_VERSION)
+
+list(PREPEND CMAKE_MODULE_PATH ${CMAKE_BINARY_DIR}/cmake)

--- a/test/test_git_clone.cmake
+++ b/test/test_git_clone.cmake
@@ -1,3 +1,7 @@
+cmake_minimum_required(VERSION 3.21)
+
+include(Assertion)
+
 # TODO: Replace `MyProject.cmake` with the correct main module file.
 include(${CMAKE_CURRENT_LIST_DIR}/../cmake/MyProject.cmake)
 
@@ -13,9 +17,8 @@ endsection()
 section("it should fail to clone an invalid Git repository")
   file(REMOVE_RECURSE repo)
 
-  assert_fatal_error(
-    CALL git_clone https://github.com repo
-    MESSAGE "Failed to clone 'https://github.com'")
+  assert_call(git_clone https://github.com repo
+    EXPECT_ERROR "^Failed to clone 'https://github.com'")
 
   assert(NOT EXISTS repo)
 endsection()


### PR DESCRIPTION
This pull request updates the [Assertion.cmake](https://github.com/threeal/assertion-cmake/) project used by this template to version [2.0.0](https://github.com/threeal/assertion-cmake/releases/tag/v2.0.0).