### PR TITLE
Prepend CMake Module Path with Sample Module Directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ project(
 option(MY_PROJECT_ENABLE_TESTS "Enable test targets.")
 option(MY_PROJECT_ENABLE_INSTALL "Enable install targets." "${PROJECT_IS_TOP_LEVEL}")
 
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
 # Prefer system packages over the find modules provided by this project.
 if(NOT DEFINED CMAKE_FIND_PACKAGE_PREFER_CONFIG)
@@ -20,8 +20,8 @@ if(NOT DEFINED CMAKE_FIND_PACKAGE_PREFER_CONFIG)
 endif()
 
 # Include the main module.
-# TODO: Replace `MyProject.cmake` with the correct main module file.
-include(cmake/MyProject.cmake)
+# TODO: Replace `MyProject` with the correct main module file.
+include(MyProject)
 
 # TODO: Replace `MY_PROJECT_ENABLE_TESTS` with the correct option.
 if(MY_PROJECT_ENABLE_TESTS)
@@ -36,9 +36,10 @@ endif()
 # TODO: Replace `MY_PROJECT_ENABLE_INSTALL` with the correct option.
 if(MY_PROJECT_ENABLE_INSTALL)
   # TODO: Rename the output file to be prefixed with the correct project name.
-  # TODO: Replace `MyProject.cmake` with the correct main module file.
+  # TODO: Replace `MyProject` with the correct main module file.
   file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/cmake/MyProjectConfig.cmake
-    "include(\${CMAKE_CURRENT_LIST_DIR}/MyProject.cmake)\n")
+    "list(PREPEND CMAKE_MODULE_PATH \${CMAKE_CURRENT_LIST_DIR})\n"
+    "include(MyProject)\n")
 
   # TODO: Rename the output file to be prefixed with the correct project name.
   include(CMakePackageConfigHelpers)

--- a/test/test_git_clone.cmake
+++ b/test/test_git_clone.cmake
@@ -2,8 +2,8 @@ cmake_minimum_required(VERSION 3.21)
 
 include(Assertion)
 
-# TODO: Replace `MyProject.cmake` with the correct main module file.
-include(${CMAKE_CURRENT_LIST_DIR}/../cmake/MyProject.cmake)
+# TODO: Replace `MyProject` with the correct main module file.
+include(MyProject)
 
 section("it should clone a Git repository")
   file(REMOVE_RECURSE repo)


### PR DESCRIPTION
This pull request resolves #133 by prepending the `CMAKE_MODULE_PATH` variable with the sample module's directory, allowing the module to be included using its name instead of the full path. This change also updates how the sample module is included in the test files.