### PR TITLE
Simplify Sample Package File Name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,6 @@ if(MY_PROJECT_ENABLE_INSTALL)
       ${CMAKE_CURRENT_BINARY_DIR}/cmake/MyProjectConfigVersion.cmake
     DESTINATION lib/cmake/MyProject)
 
-  set(CPACK_SYSTEM_NAME any)
+  set(CPACK_PACKAGE_FILE_NAME "${PROJECT_NAME}")
   include(CPack)
 endif()


### PR DESCRIPTION
This pull request resolves #135 by simplifying the sample package file name to `MyProject`, omitting the version and architecture specifiers.