### PR TITLE
Remove Dependabot Label Configuration

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,3 +6,4 @@ updates:
       interval: daily
     commit-message:
       prefix: chore
+    labels: []

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,4 +6,3 @@ updates:
       interval: daily
     commit-message:
       prefix: chore
-    labels: [chore]


### PR DESCRIPTION
This pull request resolves #141 by setting the `labels` field in the `dependabot.yaml` configuration file to an empty array.